### PR TITLE
add `gensrv` package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+
+## [0.9.0] 2023-12-15
+
+### Added
+- `gensrv` package, a wrapper around the `genserver` package
+
 ## [0.8.2] 2023-12-15
 
 ### Removed

--- a/erl/gensrv/doc.go
+++ b/erl/gensrv/doc.go
@@ -1,0 +1,5 @@
+/*
+gensrv provides a wrapper around [genserver] that removes the need for a callback struct,
+by using reflection to match callback arguments to functions.
+*/
+package gensrv

--- a/erl/gensrv/gensrv.go
+++ b/erl/gensrv/gensrv.go
@@ -1,0 +1,107 @@
+package gensrv
+
+import (
+	"reflect"
+	"time"
+
+	"github.com/uberbrodt/erl-go/erl"
+	"github.com/uberbrodt/erl-go/erl/genserver"
+)
+
+func (o *config[State]) SetName(name erl.Name) {
+	o.name = name
+}
+
+func (o *config[State]) GetName() erl.Name {
+	return o.name
+}
+
+func (o *config[State]) SetStartTimeout(tout time.Duration) {
+	o.startTimeout = tout
+}
+
+func (o *config[State]) GetStartTimeout() time.Duration {
+	return o.startTimeout
+}
+
+type CastHandle[State any] struct {
+	Arg     any
+	Handler func(self erl.PID, request any, state State) (newState State, continueTerm any, err error)
+}
+
+type CallHandle[State any] struct {
+	Arg     any
+	Handler func(self erl.PID, request any, from genserver.From, state State) (result genserver.CallResult[State], err error)
+}
+
+type GenSrvOpt[State any] func(c *config[State])
+
+func Start[State any](self erl.PID, arg any, opts ...GenSrvOpt[State]) (erl.PID, error) {
+	conf := doConf[State](opts...)
+
+	return genserver.Start[State](self, &CB[State]{conf: conf}, arg, genserver.InheritOpts(conf))
+}
+
+func StartLink[State any](self erl.PID, arg any, opts ...GenSrvOpt[State]) (erl.PID, error) {
+	conf := doConf[State](opts...)
+	return genserver.StartLink[State](self, &CB[State]{conf: conf}, arg, genserver.InheritOpts(conf))
+}
+
+func StartMonitor[State any](self erl.PID, arg any, opts ...GenSrvOpt[State]) (erl.PID, erl.Ref, error) {
+	conf := doConf[State](opts...)
+	return genserver.StartMonitor[State](self, &CB[State]{conf: conf}, arg, genserver.InheritOpts(conf))
+}
+
+func doConf[State any](opts ...GenSrvOpt[State]) *config[State] {
+	conf := &config[State]{
+		castFuns:     make(map[reflect.Type]func(self erl.PID, arg any, state State) (newState State, continu any, err error)),
+		callFuns:     make(map[reflect.Type]func(self erl.PID, request any, from genserver.From, state State) (genserver.CallResult[State], error)),
+		infoFuns:     make(map[reflect.Type]func(self erl.PID, arg any, state State) (newState State, continu any, err error)),
+		continueFuns: make(map[reflect.Type]func(self erl.PID, contTerm any, state State) (newState State, continu any, err error)),
+	}
+
+	for _, opt := range opts {
+		opt(conf)
+	}
+	return conf
+}
+
+func RegisterInit[State any](init func(self erl.PID, a any) (genserver.InitResult[State], error)) GenSrvOpt[State] {
+	return func(c *config[State]) {
+		c.initFun = init
+	}
+}
+
+func RegisterCast[State any](matchType any, fn func(self erl.PID, a any, state State) (newState State, continu any, err error)) GenSrvOpt[State] {
+	return func(c *config[State]) {
+		termT := reflect.TypeOf(matchType)
+		c.castFuns[termT] = fn
+	}
+}
+
+func RegisterInfo[State any](matchType any, fn func(self erl.PID, a any, state State) (newState State, continu any, err error)) GenSrvOpt[State] {
+	return func(c *config[State]) {
+		termT := reflect.TypeOf(matchType)
+		c.infoFuns[termT] = fn
+	}
+}
+
+func RegisterCall[State any](matchType any, fn func(self erl.PID, request any, from genserver.From, state State) (result genserver.CallResult[State], err error)) GenSrvOpt[State] {
+	return func(c *config[State]) {
+		termT := reflect.TypeOf(matchType)
+		c.callFuns[termT] = fn
+	}
+}
+
+func RegisterContinue[State any](matchType any, fn func(self erl.PID, cont any, state State) (newState State, continu any, err error)) GenSrvOpt[State] {
+	return func(c *config[State]) {
+		termT := reflect.TypeOf(matchType)
+		c.continueFuns[termT] = fn
+	}
+}
+
+func RegisterTerminate[State any](terminate func(self erl.PID, reason error, state State)) GenSrvOpt[State] {
+	return func(c *config[State]) {
+		c.terminateFun = terminate
+	}
+}

--- a/erl/gensrv/server.go
+++ b/erl/gensrv/server.go
@@ -1,0 +1,93 @@
+package gensrv
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/uberbrodt/erl-go/erl"
+	"github.com/uberbrodt/erl-go/erl/exitreason"
+
+	"github.com/uberbrodt/erl-go/erl/genserver"
+)
+
+// The initial Arg that is received in the Init callback/initially set in StartLink
+type config[State any] struct {
+	name         erl.Name
+	startTimeout time.Duration
+	initFun      func(self erl.PID, arg any) (genserver.InitResult[State], error)
+	terminateFun func(self erl.PID, reason error, state State)
+	castFuns     map[reflect.Type]func(self erl.PID, arg any, state State) (newState State, continu any, err error)
+	infoFuns     map[reflect.Type]func(self erl.PID, arg any, state State) (newState State, continu any, err error)
+	callFuns     map[reflect.Type]func(self erl.PID, request any, from genserver.From, state State) (genserver.CallResult[State], error)
+	continueFuns map[reflect.Type]func(self erl.PID, contTerm any, state State) (State, any, error)
+}
+
+// The callback implementation
+type CB[State any] struct {
+	conf *config[State]
+}
+
+// BEGIN CALLBACKS
+func (s *CB[State]) Init(self erl.PID, args any) (genserver.InitResult[State], error) {
+	var state State
+
+	if s.conf.initFun != nil {
+		return s.conf.initFun(self, args)
+	}
+	return genserver.InitResult[State]{State: state}, nil
+}
+
+func (s *CB[State]) HandleCall(self erl.PID, request any, from genserver.From, state State) (genserver.CallResult[State], error) {
+	termT := reflect.TypeOf(request)
+	for matchTerm, callFun := range s.conf.callFuns {
+		if termT == matchTerm {
+			fmt.Println("found a castfun!")
+			return callFun(self, request, from, state)
+		}
+	}
+
+	return genserver.CallResult[State]{State: state}, exitreason.Exception(fmt.Errorf("no handler for call arg: %+v", request))
+}
+
+func (s *CB[State]) HandleCast(self erl.PID, anymsg any, state State) (genserver.CastResult[State], error) {
+	termT := reflect.TypeOf(anymsg)
+	for matchTerm, castFun := range s.conf.castFuns {
+		if termT == matchTerm {
+			newState, cont, err := castFun(self, anymsg, state)
+			return genserver.CastResult[State]{State: newState, Continue: cont}, err
+		}
+	}
+
+	return genserver.CastResult[State]{State: state}, exitreason.Exception(fmt.Errorf("no handler for cast arg: %+v", anymsg))
+}
+
+func (s *CB[State]) HandleInfo(self erl.PID, anymsg any, state State) (genserver.InfoResult[State], error) {
+	termT := reflect.TypeOf(anymsg)
+	for matchTerm, infoFun := range s.conf.infoFuns {
+		if termT == matchTerm {
+			newState, cont, err := infoFun(self, anymsg, state)
+			return genserver.InfoResult[State]{State: newState, Continue: cont}, err
+		}
+	}
+
+	return genserver.InfoResult[State]{State: state}, exitreason.Exception(fmt.Errorf("no handler for info arg: %+v", anymsg))
+}
+
+func (s *CB[State]) HandleContinue(self erl.PID, continuation any, state State) (State, any, error) {
+	termT := reflect.TypeOf(continuation)
+	for matchTerm, contFun := range s.conf.continueFuns {
+		if termT == matchTerm {
+			newState, cont, err := contFun(self, continuation, state)
+			return newState, cont, err
+		}
+	}
+
+	return state, nil, exitreason.Exception(fmt.Errorf("no handler for continuation arg: %+v", continuation))
+}
+
+func (s *CB[State]) Terminate(self erl.PID, reason error, state State) {
+	if s.conf.terminateFun != nil {
+		s.conf.terminateFun(self, reason, state)
+	}
+}

--- a/erl/gensrv/server_test.go
+++ b/erl/gensrv/server_test.go
@@ -1,0 +1,125 @@
+package gensrv
+
+import (
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/uberbrodt/erl-go/erl"
+	"github.com/uberbrodt/erl-go/erl/genserver"
+)
+
+type testState struct {
+	sum int
+}
+
+type (
+	add                int
+	sub                int
+	getSum             struct{}
+	notifyTestReceiver struct{}
+)
+
+var initFn = RegisterInit[testState](func(self erl.PID, arg any) (genserver.InitResult[testState], error) {
+	startSum := arg.(int)
+
+	return genserver.InitResult[testState]{State: testState{sum: startSum}}, nil
+})
+
+var addFn = func(self erl.PID, a any, state testState) (newState testState, continu any, err error) {
+	arg := a.(add)
+	state.sum = state.sum + int(arg)
+	return state, nil, nil
+}
+
+var subFn = func(self erl.PID, a any, state testState) (newState testState, continu any, err error) {
+	arg := a.(sub)
+	state.sum = state.sum - int(arg)
+	return state, nil, nil
+}
+
+var addCast = RegisterCast[testState](add(0), addFn)
+
+var addCastNotify = RegisterCast[testState](add(0), func(self erl.PID, a any, state testState) (newState testState, continu any, err error) {
+	newState, _, err = addFn(self, a, state)
+	return newState, notifyTestReceiver{}, err
+})
+
+var subCast = RegisterCast[testState](sub(0), subFn)
+
+var subInfo = RegisterInfo[testState](sub(0), subFn)
+
+var subCastNotify = RegisterCast[testState](sub(0), func(self erl.PID, a any, state testState) (newState testState, continu any, err error) {
+	arg := a.(sub)
+	state.sum = state.sum - int(arg)
+	return state, notifyTestReceiver{}, nil
+})
+
+var sumCall = RegisterCall[testState](getSum{},
+	func(self erl.PID, request any, from genserver.From, state testState) (genserver.CallResult[testState], error) {
+		return genserver.CallResult[testState]{Msg: state.sum, State: state}, nil
+	})
+
+func TestServer_MatchesCast(t *testing.T) {
+	testPID, _ := erl.NewTestReceiver(t)
+
+	pid, err := StartLink(testPID, nil, addCast, sumCall, subCast)
+
+	assert.NilError(t, err)
+
+	genserver.Cast(pid, add(12))
+	genserver.Cast(pid, add(3))
+	result, err := genserver.Call(testPID, pid, getSum{}, 5*time.Second)
+
+	assert.NilError(t, err)
+	assert.Equal(t, result, 15)
+	genserver.Cast(pid, sub(4))
+
+	result, err = genserver.Call(testPID, pid, getSum{}, 5*time.Second)
+	assert.NilError(t, err)
+
+	assert.Equal(t, result, 11)
+}
+
+func TestServer_InitArg(t *testing.T) {
+	testPID, tr := erl.NewTestReceiver(t)
+
+	notifyCont := RegisterContinue[testState](notifyTestReceiver{}, func(self erl.PID, cont any, state testState) (newState testState, continu any, err error) {
+		erl.Send(testPID, state.sum)
+		return state, nil, nil
+	})
+
+	pid, err := StartLink(testPID, 10, initFn, addCastNotify, sumCall, subCastNotify, notifyCont)
+
+	assert.NilError(t, err)
+
+	genserver.Cast(pid, add(12))
+	result, err := genserver.Call(testPID, pid, getSum{}, 5*time.Second)
+	assert.NilError(t, err)
+	assert.Equal(t, result, 22)
+
+	tr.Loop(func(anymsg any) bool {
+		switch msg := anymsg.(type) {
+		case int:
+			assert.Equal(t, msg, 22)
+			return true
+		default:
+			return false
+
+		}
+	})
+}
+
+func TestServer_RegisterInfo(t *testing.T) {
+	testPID, _ := erl.NewTestReceiver(t)
+
+	pid, err := StartLink(testPID, 10, initFn, addCast, sumCall, subInfo)
+
+	assert.NilError(t, err)
+
+	erl.Send(pid, sub(3))
+	result, err := genserver.Call(testPID, pid, getSum{}, 5*time.Second)
+	assert.NilError(t, err)
+	assert.Equal(t, result, 7)
+}


### PR DESCRIPTION
gensrv is a wrapper around `genserver` that removes the need for a callback struct and typeswitches in favour of a reflection based approach.